### PR TITLE
use-system-binary option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,10 @@
 buildout.recipe.uwsgi
 =====================
 
-This is a `zc.buildout <http://www.buildout.org/>`_ recipe for downloading and installing uWSGI_ inside a buildout. 
+This is a `zc.buildout <http://www.buildout.org/>`_ recipe for downloading and installing uWSGI_ inside a buildout.
 Forked from `shaunsephton.recipe.uwsgi <https://github.com/shaunsephton/shaunsephton.recipe.uwsgi>`_
 
-Creates a ``bin/`` uWSGI_ executable and ``parts`` XML configuration file with which you can easily launch Buildout 
+Creates a ``bin/`` uWSGI_ executable and ``parts`` XML configuration file with which you can easily launch Buildout
 sandboxed uWSGI_ processes.
 
 
@@ -12,10 +12,10 @@ Changelog
 =========
 
 0.0.10
- 
+
 * Added the version option to allow downloading a specific version of ``uwsgi``
 * Added the possibility of specifying a certain build profile
-* Options that should go in the generated ``.xml`` file should be ``xml-`` prefixed 
+* Options that should go in the generated ``.xml`` file should be ``xml-`` prefixed
 
 
 
@@ -36,6 +36,15 @@ This allows you to start a uWSGI_ process configured by the generated XML file, 
 
     $ ./bin/uwsgi --xml parts/uwsgi/uwsgi.xml
 
+It is also possible to use an "external" uwsgi binary (installed by the means of the OS package manager or compiled manually) and just let the recipe to generate the xml file with settings:
+
+    [uwsgi]
+    recipe=buildout.recipe.uwsgi
+    use-system-binary = True
+
+And then run it with
+
+    $ /usr/bin/uwsgi --xml parts/uwsgi/uwsgi.xml
 
 You can specify any and all additional uWSGI_ configuration options as additional options of the Buildout part. These should be prefixed with ``xml-``. For instance to specify a socket and module and to enable the master process add ``xml-socket``, ``xml-module`` and ``xml-master`` options to the buildout part, i.e.::
 
@@ -48,7 +57,7 @@ You can specify any and all additional uWSGI_ configuration options as additiona
     xml-socket=127.0.0.1:7001
     xml-module=my_uwsgi_package.wsgi
     xml-master=True
-    
+
 
 .. _uWSGI: http://projects.unbit.it/uwsgi/wiki/Doc
 

--- a/buildout/recipe/uwsgi.py
+++ b/buildout/recipe/uwsgi.py
@@ -59,11 +59,11 @@ class UWSGI:
 
         #
         # Set the environment
-        # Call make 
+        # Call make
         #
         profile = self.options.get('profile', 'default.ini')
         os.environ['UWSGI_PROFILE'] = profile
-        
+
         subprocess.check_call(['make', '-f', 'Makefile'])
 
 
@@ -137,21 +137,23 @@ class UWSGI:
 
     def install(self):
         paths = []
-        if not os.path.exists(os.path.join(self.buildout['buildout']['bin-directory'], self.name)):
-            # Download uWSGI.
-            download_path = self.download_release()
 
-            #Extract uWSGI.
-            uwsgi_path, extract_path = self.extract_release(download_path)
+        if self.options.get('use-system-binary', False):
+            if not os.path.exists(os.path.join(self.buildout['buildout']['bin-directory'], self.name)):
+                # Download uWSGI.
+                download_path = self.download_release()
 
-            # Build uWSGI.
-            uwsgi_executable_path = self.build_uwsgi(uwsgi_path)
+                #Extract uWSGI.
+                uwsgi_path, extract_path = self.extract_release(download_path)
 
-            # Copy uWSGI to bin.
-            paths.append(self.copy_uwsgi_to_bin(uwsgi_executable_path))
+                # Build uWSGI.
+                uwsgi_executable_path = self.build_uwsgi(uwsgi_path)
 
-            # Remove extracted uWSGI package.
-            shutil.rmtree(extract_path)
+                # Copy uWSGI to bin.
+                paths.append(self.copy_uwsgi_to_bin(uwsgi_executable_path))
+
+                # Remove extracted uWSGI package.
+                shutil.rmtree(extract_path)
 
         # Create uWSGI conf xml.
         paths.append(self.create_conf_xml())


### PR DESCRIPTION
Good day,

I've been in a need to serve my buildout-based app with a system uwsgi binary (installed from the OS repositories)

I've added an option to buildout.recipe.uwsgi to skip downloading and building uwsgi but still to generate the xml config which can then be used with the system uwsgi.

This is a simple one-line change and does not affect the behaviour of existing buildouts.
