### PR TITLE
set env-var PYTHON_BIN to compile uwsgi with correct python-version

### DIFF
--- a/buildout/recipe/uwsgi.py
+++ b/buildout/recipe/uwsgi.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import subprocess
 import setuptools
 import shutil
@@ -74,6 +75,7 @@ class UWSGI:
         #
         profile = self.options.get("profile", "default.ini")
         os.environ["UWSGI_PROFILE"] = profile
+        os.environ["PYTHON_BIN"] = sys.executable
 
         subprocess.check_call(["make", "-f", "Makefile"])
 


### PR DESCRIPTION
with the commit https://github.com/unbit/uwsgi/commit/d584857c781593d6c1f7f2a98503fcdce2ed9893
uwsgi is able handle different python-binaries in the Makefile so its
possible to set the env-var PYTHON_BIN to the desired python-version.
Now we like to compile uwsgi with the python-version buildout is
running (otherwise its possible compile uwsgi with python2.6 because it's
your system default and now wit i.e. python2.7 buildout is running with)
In this commit we set the env-var PYTHON_BIN to currently running
python-bin with sys.executable
